### PR TITLE
Add project README with plugin index and ideas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Claude Personal Marketplace
+
+## About
+Claude Personal Marketplace is a collection of personal plugins that extend workflows and tools for Claude-based automation, starting with integrations for working in Obsidian vaults.
+
+## Plugin Index
+- **Obsidian** (`plugins/obsidian`): A plugin to work with Obsidian vaults. Provides command prompts like `today` and `process-meeting` for daily notes and meeting processing.
+
+## Plugin Ideas (Todo)
+- [ ] Add a plugin for task tracking integrations (e.g., Todoist/Things).
+- [ ] Add a plugin for calendar scheduling workflows.
+- [ ] Add a plugin for research capture (web clipping + highlights).
+- [ ] Add a plugin for Markdown publishing/export pipelines.
+- [ ] Add a plugin for knowledge graph or backlink analysis.


### PR DESCRIPTION
### Motivation
- Add a top-level `README.md` to explain the repository purpose, surface available plugins, and track ideas for future plugins.

### Description
- Create `README.md` with an "About" section, a "Plugin Index" that lists **Obsidian** (`plugins/obsidian`) and its commands (`today`, `process-meeting`), and a "Plugin Ideas (Todo)" list of potential new plugins.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69729dd1461083279a2ed358edc230e4)