### PR TITLE
Add README for Obsidian plugin

### DIFF
--- a/plugins/obsidian/README.md
+++ b/plugins/obsidian/README.md
@@ -1,0 +1,15 @@
+# Obsidian Plugin
+
+## About
+This plugin defines the command and skill prompts used to automate tasks inside the Obsidian vault, such as generating daily notes or scaffolding new notes with consistent structure.
+
+## Commands
+| Command | Description |
+| --- | --- |
+| `process-meeting` | Placeholder for processing meeting notes; currently no command instructions are defined. |
+| `today` | Generates a daily summary note in `dailies/` with meetings, tasks, and daily notes sections. |
+
+## TODO
+- Flesh out the `process-meeting` command with a full workflow for summarizing meetings and capturing action items.
+- Add more daily note automation, such as tagging rules or automatic links to related notes.
+- Document and expand available skills beyond `new-note` to cover common vault workflows.


### PR DESCRIPTION
### Motivation
- Provide basic documentation for the Obsidian plugin to describe its purpose, list available commands, and suggest next steps for development of the `plugins/obsidian` code.

### Description
- Add `plugins/obsidian/README.md` containing an About section, a Commands index that describes `process-meeting` and `today`, and a TODO section with enhancement ideas for the plugin.

### Testing
- No automated tests were run since this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69729e8f2b64832788a22bee4d70e220)