### PR TITLE
Remove explicit content sections from process-meeting

### DIFF
--- a/plugins/obsidian/README.md
+++ b/plugins/obsidian/README.md
@@ -6,10 +6,9 @@ This plugin defines the command and skill prompts used to automate tasks inside 
 ## Commands
 | Command | Description |
 | --- | --- |
-| `process-meeting` | Placeholder for processing meeting notes; currently no command instructions are defined. |
+| `process-meeting` | Process a meeting transcript into structured notes with summary, tasks, and decisions. |
 | `today` | Generates a daily summary note in `dailies/` with meetings, tasks, and daily notes sections. |
 
 ## TODO
-- Flesh out the `process-meeting` command with a full workflow for summarizing meetings and capturing action items.
 - Add more daily note automation, such as tagging rules or automatic links to related notes.
 - Document and expand available skills beyond `new-note` to cover common vault workflows.

--- a/plugins/obsidian/commands/process-meeting.md
+++ b/plugins/obsidian/commands/process-meeting.md
@@ -1,0 +1,13 @@
+---
+description: Process a meeting transcript into structured notes
+---
+
+When asked by the user, take the available meeting notes or transcript and turn it into a structured meeting note.
+
+The note should follow this structure and align with any available meeting note templates in the vault:
+
+Front matter:
+  - Tags: list of relevant tags for the meeting (remove `unprocessed` if present)
+  - Participants: list of participant names if available
+
+Focus on concise, searchable bullets in each section defined by the relevant template. If the transcript or notes include action items, capture them as tasks with clear owners or due dates when possible.


### PR DESCRIPTION
### Motivation
- Remove the hard-coded list of meeting content sections so notes follow the vault's existing meeting templates rather than an embedded example. 
- Clarify expected front matter metadata such as `Tags` (including removal of `unprocessed`) and `Participants` to ensure consistent, searchable notes.

### Description
- Update `plugins/obsidian/commands/process-meeting.md` to remove the explicit content section list and replace it with a directive to follow the relevant meeting template. 
- Clarify front matter guidance to include `Tags` and `Participants` and instruct capturing action items as tasks with owners or due dates when possible. 
- Minor README wording was adjusted to describe `process-meeting` as producing structured meeting notes.

### Testing
- No automated tests were run because these are documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6972a1652e688327aaccb743f4a8e9f4)