### PR TITLE
Add /process-meeting argument hint and bump Obsidian plugin version

### DIFF
--- a/plugins/obsidian/.claude-plugin/plugin.json
+++ b/plugins/obsidian/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "obsidian",
   "description": "A plugin to work with Obsidian vaults.",
-  "version": "1.6.1",
+  "version": "1.7.1",
   "author": {
     "name": "Carl Stålhem",
     "url": "https://github.com/cstalhem"

--- a/plugins/obsidian/.claude-plugin/plugin.json
+++ b/plugins/obsidian/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "obsidian",
   "description": "A plugin to work with Obsidian vaults.",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": {
     "name": "Carl Stålhem",
     "url": "https://github.com/cstalhem"

--- a/plugins/obsidian/skills/process-meeting/SKILL.md
+++ b/plugins/obsidian/skills/process-meeting/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: process-meeting
 description: Process Obsidian meeting transcripts into structured meeting notes following vault conventions.
+argument-hint: <transcript-file> <meeting-note-file>
 context: fork
 disable-model-invocation: true
 allowed-tools: Bash, Read, Write, Edit


### PR DESCRIPTION
### Motivation
- Surface the expected inputs for the `/process-meeting` command so users know to supply a transcript file and a target meeting-note path, and update the plugin version to reflect this metadata change.

### Description
- Added `argument-hint: <transcript-file> <meeting-note-file>` to `plugins/obsidian/skills/process-meeting/SKILL.md` and bumped `version` to `1.6.1` in `plugins/obsidian/.claude-plugin/plugin.json`.

### Testing
- Validated `plugins/obsidian/.claude-plugin/plugin.json` with `python -m json.tool` (OK), inspected the local diffs for the modified files, and noted an external `curl` network check failed with an HTTP tunnel `403` in this environment.

Closes #8 

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698bb94d50a08327b009e9575ca7212b)