### PR TITLE
knowledge-system: align with current Claude Code docs + push-time reflection hook (3.2.0)

### DIFF
--- a/plugins/knowledge-system/.claude-plugin/plugin.json
+++ b/plugins/knowledge-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "knowledge-system",
   "description": "Bootstrap and maintain a three-tier knowledge system (AGENTS.md, rules, skills) with retrieval, promotion, and self-healing.",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "author": {
     "name": "Carl Stålhem",
     "url": "https://github.com/cstalhem"

--- a/plugins/knowledge-system/hooks/hooks.json
+++ b/plugins/knowledge-system/hooks/hooks.json
@@ -1,5 +1,4 @@
 {
-  "description": "Auto-trigger knowledge system skills at lifecycle events",
   "hooks": {
     "SessionStart": [
       {
@@ -7,19 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/retrieve-on-start.sh",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/retrieve-on-start.sh\"",
             "timeout": 5
-          }
-        ]
-      }
-    ],
-    "PreToolUse": [
-      {
-        "matcher": "Edit|Write",
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "If you have not yet consulted the knowledge system for rules and skills relevant to the files being edited, run the retrieve-knowledge skill now before proceeding."
           }
         ]
       }

--- a/plugins/knowledge-system/hooks/hooks.json
+++ b/plugins/knowledge-system/hooks/hooks.json
@@ -11,6 +11,18 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/reflect-on-push.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/knowledge-system/hooks/reflect-on-push.sh
+++ b/plugins/knowledge-system/hooks/reflect-on-push.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+# PostToolUse(Bash) hook: when Claude publishes work (git push / gh pr create),
+# remind it to reflect on whether the work warrants a knowledge-system update.
+# Reads the hook payload from stdin and emits context only on a match, so every
+# other Bash command is a no-op. PostToolUse fires only after the tool succeeds,
+# so a failed push never triggers the reminder.
+
+payload="$(cat)"
+
+if printf '%s' "$payload" | grep -Eq 'git[[:space:]]+push|gh[[:space:]]+pr[[:space:]]+create'; then
+  cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": "Work was just published. Reflect on whether anything discovered during it warrants a knowledge-system update — a new rule, skill, critical pattern, or staging entry. If so, capture it now and commit the change as a follow-up. If nothing qualifies, continue without changes."
+  }
+}
+EOF
+fi

--- a/plugins/knowledge-system/hooks/retrieve-on-start.sh
+++ b/plugins/knowledge-system/hooks/retrieve-on-start.sh
@@ -2,10 +2,6 @@
 set -euo pipefail
 
 # SessionStart hook: remind Claude to retrieve relevant knowledge.
-# Command hooks communicate via JSON stdout with a systemMessage field.
+# For SessionStart, stdout text is added to Claude's context before the first prompt.
 
-cat <<'EOF'
-{
-  "systemMessage": "A new session has started. Run the retrieve-knowledge skill to scan for rules, skills, and critical patterns relevant to this session before beginning work."
-}
-EOF
+echo "A new session has started. Run the retrieve-knowledge skill to scan for rules, skills, and critical patterns relevant to this session before beginning work."

--- a/plugins/knowledge-system/skills/init/SKILL.md
+++ b/plugins/knowledge-system/skills/init/SKILL.md
@@ -12,7 +12,7 @@ allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Agent, TaskCreate, TaskUpdat
 
 Bootstrap a three-tier knowledge system for any project. Produces:
 
-- **L1 (Orientation):** AGENTS.md or CLAUDE.md with project overview, commands, design assumptions, and the Knowledge System section
+- **L1 (Orientation):** `CLAUDE.md` (the file Claude Code loads) with project overview, commands, design assumptions, and the Knowledge System section — sharable with other agents by keeping the content in `AGENTS.md` and symlinking `CLAUDE.md → AGENTS.md`
 - **L2 (Rules):** `.claude/rules/*.md` with path-scoped one-line rules
 - **L3 (Skills):** `.claude/skills/*/SKILL.md` with deep reference material
 - **Staging area:** Project-specific `MEMORY.md` for unvalidated learnings
@@ -56,7 +56,7 @@ Run 3-4 focused AskUserQuestion rounds:
 1. **Project purpose & context** — What does this project do? Is it personal or team? What's the development stage?
 2. **Dev environment & conventions** — Preferred package manager, test approach, any strong conventions? Anything Claude should never do?
 3. **Known gotchas** — Any sharp edges, tricky configurations, or "things you always forget"?
-4. **L1 file choice** — AGENTS.md (if collaborators/agents will read it) or CLAUDE.md (personal project)?
+4. **L1 file** — Should other AI agents (Cursor, Copilot, etc.) share these instructions? If yes, make `AGENTS.md` the real file and symlink `CLAUDE.md → AGENTS.md` (or, when Claude-specific content is also needed, use a `CLAUDE.md` whose first line is `@AGENTS.md`). If no, use `CLAUDE.md` directly. Claude Code only loads `CLAUDE.md`.
 
 ### Partial
 
@@ -159,7 +159,7 @@ Group proposed rules by file with path scoping shown:
 ```
 
 **L3 — Skills**
-List each proposed skill with name, description (<200 chars), and a one-line summary of what it would contain:
+List each proposed skill with name, `description` (what it does), `when_to_use` (trigger phrases), and a one-line summary of what it would contain:
 
 ```
 chakra-ui-v3 — "Chakra UI v3 component patterns..."
@@ -217,7 +217,8 @@ Create each skill directory with SKILL.md:
 ```markdown
 ---
 name: skill-name
-description: "Under 200 chars describing when to use this skill"
+description: "What the skill does — lead with the key use case"
+when_to_use: "Trigger phrases or example requests that should load this skill"
 ---
 
 # Skill Title
@@ -243,7 +244,7 @@ Tables or flowcharts for common decisions (when applicable).
 
 **Skills writing guide:**
 
-- Description must be under 200 characters
+- `description` states what the skill does, leading with the key use case; `when_to_use` holds trigger phrases and example requests. The two are concatenated in the skill listing and truncated at 1,536 characters combined — keep both tight
 - Key Patterns section should include real code examples from the project where possible
 - Anti-Patterns use story format: what went wrong → why → fix
 - Decision Aids are optional — only include when there are genuine multi-path decisions
@@ -254,9 +255,12 @@ Tables or flowcharts for common decisions (when applicable).
 Read the template from this skill's references directory:
 `${CLAUDE_SKILL_DIR}/references/knowledge-system-template.md`
 
-Insert it into the project's L1 file (AGENTS.md or CLAUDE.md), replacing `{L1_FILE}` with the actual filename. Place it after the main project content but before any MCP/tools section if one exists.
+Claude Code loads `CLAUDE.md`, not `AGENTS.md`. Resolve the real L1 file from the Phase 2 choice:
 
-If the L1 file doesn't exist yet, create it with the full project overview content followed by the Knowledge System section.
+- **CLAUDE.md only:** the real file is `CLAUDE.md`.
+- **Shared with other agents:** the real file is `AGENTS.md`; ensure `CLAUDE.md` resolves to it via symlink (`ln -s AGENTS.md CLAUDE.md`) or a `CLAUDE.md` whose first line is `@AGENTS.md`.
+
+Insert the template into the real L1 file, replacing `{L1_FILE}` with its filename. Place it after the main project content but before any MCP/tools section if one exists. If the file doesn't exist yet, create it with the full project overview content followed by the Knowledge System section.
 
 ### Step 5: Staging area
 

--- a/plugins/knowledge-system/skills/init/references/critical-patterns-template.md
+++ b/plugins/knowledge-system/skills/init/references/critical-patterns-template.md
@@ -1,6 +1,5 @@
 ---
 description: "High-impact WRONG/CORRECT patterns — mistakes that break builds, cause data loss, or create security issues"
-paths: ["**"]
 ---
 
 # Critical Patterns

--- a/plugins/knowledge-system/skills/init/references/knowledge-system-template.md
+++ b/plugins/knowledge-system/skills/init/references/knowledge-system-template.md
@@ -7,7 +7,7 @@ Project knowledge lives in three tiers. Each has a distinct purpose and update t
 | Tier        | Location                | Loads                | Contains                                               |
 | ----------- | ----------------------- | -------------------- | ------------------------------------------------------ |
 | Orientation | `{L1_FILE}` (this file) | Always               | Project structure, commands, design assumptions        |
-| Rules       | `.claude/rules/`        | Always (path-scoped) | Concise do/don't rules                                 |
+| Rules       | `.claude/rules/`        | At launch, or on read if path-scoped | Concise do/don't rules                 |
 | Skills      | `.claude/skills/`       | On demand            | Deep reference: examples, anti-patterns, decision aids |
 
 **Staging area** — unvalidated learnings are stored as individual `staging_*.md` files in the project's memory directory (same directory as `MEMORY.md`), with index lines in `MEMORY.md` prefixed with `- [staging:`. This integrates with the auto-memory system rather than conflicting with it.
@@ -26,7 +26,7 @@ When you discover something worth capturing during work:
 1. **Caused by a mistake or gotcha?** → Add a one-line rule to the relevant file in `.claude/rules/`. Update the matching skill's Anti-Patterns section with the full context (what went wrong, why, the fix).
 2. **High-impact mistake (build-breaking, data loss, security)?** → Add a WRONG/CORRECT entry to `.claude/rules/critical-patterns.md`.
 3. **New pattern, example, or decision aid?** → Update the relevant skill in `.claude/skills/`.
-4. **New topic not covered by any existing skill?** → Create a new skill directory with `SKILL.md`. Keep description under 200 chars.
+4. **New topic not covered by any existing skill?** → Create a new skill directory with `SKILL.md`. Put what the skill does in `description` and trigger phrases in `when_to_use` (the two are truncated at 1,536 characters combined in the skill listing).
 5. **Not validated yet?** → Create a `staging_<slug>.md` file in the project's memory directory with frontmatter tags (`[staging] [type:gotcha|pattern|decision] [area:<project-area>]`) and add an index line to `MEMORY.md` prefixed with `- [staging:`. Add `[promotion-candidate]` to the description when the pattern recurs across 2+ sessions.
 
 ### Cross-referencing
@@ -41,5 +41,5 @@ When you discover something worth capturing during work:
 - When staging entries (files prefixed `staging_*` in the memory directory) have been validated across 2+ sessions, suggest promotion.
 - When a rule or skill leads to incorrect behavior, flag it: critical issues → propose a direct fix (with user approval), minor issues → create a staging entry with `[type:gotcha]` and `[promotion-candidate]` tags.
 - Keep rules to one line each — no code examples, no rationale (that belongs in skills).
-- Keep skill content timeless — no phase numbers, plan numbers, or session-specific context.
+- Write each entry as durable facts plus the reason it exists. Exclude conversational artifacts (prior assumptions, who proposed a change, session narration) and anything already recorded in the repo or another tier. Rules carry the fact in one line and link to a skill for the reason; skills, critical patterns, and staging entries state the reason inline. No phase numbers, plan numbers, or session-specific context.
 - Surface lint/type/test errors immediately rather than deferring them.


### PR DESCRIPTION
Validates the `knowledge-system` plugin against current Claude Code documentation, fixes the incompatibilities found, then adds a push-time reflection hook.

## Doc-compatibility fixes
- **L1 orientation**: use `CLAUDE.md` (the only file Claude Code loads); share with other agents via symlink or `@AGENTS.md` import instead of treating `AGENTS.md` as an interchangeable L1 file.
- **SessionStart hook**: emit the reminder via stdout instead of the inert `systemMessage` JSON field so it actually reaches Claude's context.
- **critical-patterns**: drop `paths: ["**"]` so it loads unconditionally at launch.
- **hooks.json**: remove the stateless `PreToolUse` prompt hook; drop the undocumented top-level `description` key; quote `${CLAUDE_PLUGIN_ROOT}`.
- **skill description guidance**: correct the bogus 200-char limit to the real 1,536-char combined `description` + `when_to_use` cap, and add a durable-facts writing standard to the knowledge-system template.

## New: push-time reflection hook
- `PostToolUse(Bash)` hook fires on `git push` / `gh pr create` and reminds Claude to reflect on whether the completed work warrants a knowledge-system update, captured as a follow-up commit.
- Forge-agnostic (keyed on the commands, not GitHub), fires only on a successful publish, and is a nudge via `additionalContext` (never blocks).

Bumps plugin version `3.1.0 -> 3.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)