### PR TITLE
Bootstrap repo knowledge system + README/description cleanup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
     {
       "name": "knowledge-system",
       "source": "./plugins/knowledge-system",
-      "description": "Bootstrap a three-tier knowledge system (AGENTS.md, rules, skills) for any project."
+      "description": "Bootstrap a three-tier knowledge system (CLAUDE.md, rules, skills) for any project."
     },
     {
       "name": "codex-review",

--- a/.claude/rules/conventions.md
+++ b/.claude/rules/conventions.md
@@ -1,0 +1,21 @@
+---
+description: "Cross-cutting conventions for maintaining the Cargus Forge plugin marketplace"
+---
+
+# Conventions
+
+## Plugins & manifests
+
+- Bump the plugin's `plugin.json` `version` (SemVer) in the same commit as any change to that plugin (see skill: plugin-release).
+- SemVer: bump MAJOR for breaking changes, MINOR for new features, PATCH for fixes.
+- Register every new plugin in both `.claude-plugin/marketplace.json` and the README plugin index.
+- Keep each plugin's description identical across its `plugin.json`, `marketplace.json`, and the README.
+- A marketplace entry's `source` must point to the plugin's real directory under `plugins/`.
+- Edit `plugin.json` and `marketplace.json` by hand — they are not package-manager files.
+- `author`/`owner` use `{ "name": "Carl Stålhem" }`; a plugin's `author` also includes `"url"`.
+
+## Git workflow
+
+- Branch from `main`; never commit plugin changes directly to `main`.
+- Rebase-merge PRs to keep `main` history linear.
+- Validate with `claude plugin validate ./plugins/<name>` (add `--strict` in CI) before opening a PR.

--- a/.claude/rules/critical-patterns.md
+++ b/.claude/rules/critical-patterns.md
@@ -1,0 +1,44 @@
+---
+description: "High-impact WRONG/CORRECT patterns — mistakes that break builds, cause data loss, or create security issues"
+---
+
+# Critical Patterns
+
+<!--
+This file captures high-impact mistakes in WRONG/CORRECT format.
+Only add patterns here that meet the severity threshold:
+- Build-breaking errors
+- Data loss or corruption
+- Security vulnerabilities
+- Silent failures that are hard to debug
+
+Format for each entry:
+
+## <Short description>
+
+WRONG:
+```
+code or command that causes the problem
+```
+
+CORRECT:
+```
+code or command that avoids the problem
+```
+
+Why: One-line explanation of the root cause.
+-->
+
+## Shipping a plugin change without bumping plugin.json version
+
+WRONG:
+```
+# edit a plugin, commit, push — leave "version" unchanged
+```
+
+CORRECT:
+```
+# bump plugins/<name>/.claude-plugin/plugin.json "version" (SemVer) in the same commit
+```
+
+Why: With an explicit `version` set, Claude Code caches by version string — users never receive the change and `/plugin update` reports "already at the latest version". A silent no-op that is hard to debug.

--- a/.claude/skills/plugin-release/SKILL.md
+++ b/.claude/skills/plugin-release/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: plugin-release
+description: "Release workflow for a Cargus Forge plugin — validate, version-bump, sync descriptions, commit, PR, merge"
+when_to_use: "When shipping a change to any plugin in this repo: cutting a release, bumping a version, or opening and merging a plugin PR"
+---
+
+# Releasing a plugin
+
+The end-to-end workflow for shipping a change to a plugin in this marketplace.
+
+## Steps
+
+1. **Validate** — `claude plugin validate ./plugins/<name>` (use `--strict` to treat warnings as errors). Wrong field types (e.g. a string where an array is expected) are load errors; unrecognized fields are warnings only.
+2. **Bump the version** — edit `plugins/<name>/.claude-plugin/plugin.json` `version` in the same commit as the change. SemVer: MAJOR for breaking changes, MINOR for new features, PATCH for fixes.
+3. **Sync descriptions** — if the plugin's description changed, update it identically in `plugin.json`, `.claude-plugin/marketplace.json`, and the README plugin index.
+4. **Branch & commit** — branch from `main`; commit the plugin change and the version bump together.
+5. **Push & PR** — push the branch and open the PR against `main`.
+6. **Merge** — rebase-merge to keep `main` linear, and delete the branch.
+
+## Anti-Patterns
+
+- **What went wrong:** Pushed plugin changes without bumping `version`.
+  **Why:** With an explicit `version`, Claude Code caches by version string, so users never receive the update and `/plugin update` reports "already at the latest version" — a silent no-op.
+  **Fix:** Always bump `version` in the same commit (see `.claude/rules/conventions.md` and `.claude/rules/critical-patterns.md`).
+
+- **What went wrong:** `git push` or `gh pr create` hung with an SSH timeout, or failed with `Permission denied (publickey)`.
+  **Why:** Those commands need the unsandboxed environment (SSH keys and network egress); the remote configuration itself is fine.
+  **Fix:** Run `git push` and `gh` outside the command sandbox. Do not work around it by rewriting the SSH remote to an HTTPS push.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# Cargus Forge
+
+A marketplace monorepo of Claude Code plugins for knowledge management, note-taking workflows, and Claude Code productivity.
+
+## Repository layout
+
+- `plugins/<name>/` — one self-contained plugin each:
+  - `.claude-plugin/plugin.json` — manifest (`name`, `description`, `version`, `author`)
+  - `skills/<skill>/SKILL.md`, `agents/`, `hooks/hooks.json` — components, auto-discovered when the plugin is installed
+- `.claude-plugin/marketplace.json` — root marketplace listing every plugin (`name`, `source`, `description`)
+- `README.md` — human-facing plugin index
+
+Current plugins: `obsidian`, `knowledge-system`, `codex-review`, `adr-management`.
+
+## Local development loop
+
+- Test a plugin without installing it: `claude --plugin-dir ./plugins/<name>` (takes precedence over an installed copy of the same name)
+- After editing an installed plugin: `/reload-plugins` (reloads skills, agents, hooks, and plugin MCP/LSP servers without a restart)
+- Validate before opening a PR: `claude plugin validate ./plugins/<name>` (add `--strict` to treat warnings as errors)
+
+## Component authoring
+
+For how to write skills, agents, hooks, commands, MCP/LSP config, and plugin directory structure, use the installed **`plugin-dev`** plugin and the official docs. This repo's knowledge system does not restate that general guidance — it captures only this repo's wiring and conventions.
+
+# Knowledge System
+
+The purpose of this system is to make each change to the code simpler than the last, by continually capturing gotchas, patterns, and decisions as they're discovered.
+
+Project knowledge lives in three tiers. Each has a distinct purpose and update trigger.
+
+| Tier        | Location                | Loads                | Contains                                               |
+| ----------- | ----------------------- | -------------------- | ------------------------------------------------------ |
+| Orientation | `CLAUDE.md` (this file) | Always               | Project structure, commands, design assumptions        |
+| Rules       | `.claude/rules/`        | At launch, or on read if path-scoped | Concise do/don't rules                 |
+| Skills      | `.claude/skills/`       | On demand            | Deep reference: examples, anti-patterns, decision aids |
+
+**Staging area** — unvalidated learnings are stored as individual `staging_*.md` files in the project's memory directory (same directory as `MEMORY.md`), with index lines in `MEMORY.md` prefixed with `- [staging:`. This integrates with the auto-memory system rather than conflicting with it.
+
+**Critical patterns** — `.claude/rules/critical-patterns.md` captures high-impact WRONG/CORRECT patterns for mistakes that break builds, cause data loss, or create security issues.
+
+### Workflow checkpoints
+
+- **Before non-trivial tasks:** Scan `.claude/rules/` (including `critical-patterns.md`) and `.claude/skills/` for knowledge relevant to the task at hand. Skip for trivial changes (typos, copy edits, color tweaks, one-line fixes).
+- **After completing tasks:** Check if anything discovered during the task should be staged in `MEMORY.md`.
+
+### Updating the knowledge system
+
+When you discover something worth capturing during work:
+
+1. **Caused by a mistake or gotcha?** → Add a one-line rule to the relevant file in `.claude/rules/`. Update the matching skill's Anti-Patterns section with the full context (what went wrong, why, the fix).
+2. **High-impact mistake (build-breaking, data loss, security)?** → Add a WRONG/CORRECT entry to `.claude/rules/critical-patterns.md`.
+3. **New pattern, example, or decision aid?** → Update the relevant skill in `.claude/skills/`.
+4. **New topic not covered by any existing skill?** → Create a new skill directory with `SKILL.md`. Put what the skill does in `description` and trigger phrases in `when_to_use` (the two are truncated at 1,536 characters combined in the skill listing).
+5. **Not validated yet?** → Create a `staging_<slug>.md` file in the project's memory directory with frontmatter tags (`[staging] [type:gotcha|pattern|decision] [area:<project-area>]`) and add an index line to `MEMORY.md` prefixed with `- [staging:`. Add `[promotion-candidate]` to the description when the pattern recurs across 2+ sessions.
+
+### Cross-referencing
+
+- Rules reference backing skills: `(see skill: skill-name)` for deeper context.
+- Skills reference the rules they support for quick lookup.
+
+### Proactive maintenance
+
+- After fixing a bug caused by a missing rule, suggest adding the rule.
+- After a session where a skill would have prevented confusion, suggest updating it.
+- When staging entries (files prefixed `staging_*` in the memory directory) have been validated across 2+ sessions, suggest promotion.
+- When a rule or skill leads to incorrect behavior, flag it: critical issues → propose a direct fix (with user approval), minor issues → create a staging entry with `[type:gotcha]` and `[promotion-candidate]` tags.
+- Keep rules to one line each — no code examples, no rationale (that belongs in skills).
+- Write each entry as durable facts plus the reason it exists. Exclude conversational artifacts (prior assumptions, who proposed a change, session narration) and anything already recorded in the repo or another tier. Rules carry the fact in one line and link to a skill for the reason; skills, critical patterns, and staging entries state the reason inline. No phase numbers, plan numbers, or session-specific context.
+- Surface lint/type/test errors immediately rather than deferring them.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Plugins for knowledge management, note-taking workflows, and Claude Code product
 
 ## Plugin Index
 - **Obsidian** (`plugins/obsidian`): Daily notes, meeting processing, task management, and note creation for Obsidian vaults.
-- **Knowledge System** (`plugins/knowledge-system`): Bootstrap a three-tier knowledge system (AGENTS.md, rules, skills) for any project with guided research and adaptive questioning.
+- **Knowledge System** (`plugins/knowledge-system`): Bootstrap a three-tier knowledge system (CLAUDE.md, rules, skills) for any project with guided research and adaptive questioning.
 - **Codex Review** (`plugins/codex-review`): Iteratively refine a plan document with feedback from the Codex CLI until it has no blocking concerns left.
+- **ADR Management** (`plugins/adr-management`): Create and maintain Architecture Decision Records (ADRs) as living documents, with a litmus test for what earns a record.
 
 ## Plugin Ideas (Todo)
 - [ ] Add a plugin for task tracking integrations (e.g., Todoist/Things).

--- a/plugins/knowledge-system/.claude-plugin/plugin.json
+++ b/plugins/knowledge-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "knowledge-system",
-  "description": "Bootstrap and maintain a three-tier knowledge system (AGENTS.md, rules, skills) with retrieval, promotion, and self-healing.",
-  "version": "3.2.0",
+  "description": "Bootstrap and maintain a three-tier knowledge system (CLAUDE.md, rules, skills) with retrieval, promotion, and self-healing.",
+  "version": "3.2.1",
   "author": {
     "name": "Carl Stålhem",
     "url": "https://github.com/cstalhem"


### PR DESCRIPTION
Bootstraps a three-tier knowledge system for the Cargus Forge repo (via the `knowledge-system` plugin's `init-memory` flow) and cleans up the README index and stale plugin descriptions.

## Knowledge system (commit 1)
- **L1 `CLAUDE.md`**: repo layout, local dev loop (`--plugin-dir`, `/reload-plugins`, `claude plugin validate`), an explicit pointer to the installed `plugin-dev` plugin for component authoring (no duplication), and the Knowledge System section.
- **L2 `.claude/rules/conventions.md`**: always-loaded manifest/version/description-sync and git-workflow conventions.
- **L2 `.claude/rules/critical-patterns.md`**: seeded with the version-bump silent-cache failure (forgetting to bump `plugin.json` `version` means users silently never get the update).
- **L3 `.claude/skills/plugin-release/SKILL.md`**: the repo's validate → bump → sync → branch → PR → rebase-merge workflow, with anti-patterns. Deliberately no overlap with `plugin-dev`.

Official-docs research (Phase 3) confirmed the version-bump silent-failure behavior and the `claude plugin validate [--strict]` pre-PR gate; both are reflected above. All other plugin-authoring guidance is left to `plugin-dev`.

## Cleanup (commit 2)
- Add **ADR Management** to the README plugin index (was missing; it was already in `marketplace.json`).
- Correct `AGENTS.md` -> `CLAUDE.md` across README, `marketplace.json`, and knowledge-system `plugin.json` to match the current L1 design.
- Bump knowledge-system `3.2.0 -> 3.2.1` (description change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)